### PR TITLE
mobile hero fix and mobile menu click on anchor elemets

### DIFF
--- a/acf-blocks/frontpage-hero/frontpage-hero.scss
+++ b/acf-blocks/frontpage-hero/frontpage-hero.scss
@@ -134,6 +134,7 @@ body.wp-admin [data-type="acf/frontpage-hero"] {
 
   &__image {
     min-width: 100vw;
+    height: calc(100vh - 3.5rem);
     min-height: 31.25rem;
 
     img {

--- a/app/js/modules/navigation.ts
+++ b/app/js/modules/navigation.ts
@@ -366,6 +366,29 @@ function initNavigation() {
     updateMobileMenuOffset();
   }
 
+  mobileSubMenuToggles?.forEach((toggle) => toggle?.addEventListener('click', () => toggleSubMenu({ toggle, menu: mobileMenu })));
+
+  function handleAnchorLinkClick(event: Event) {
+    const target = event.currentTarget as HTMLAnchorElement;
+    const href = target.getAttribute('href');
+
+    if (href && href.startsWith('#')) {
+      if (mobileMenuDialog?.open) {
+        closeDialog(mobileMenuDialog, dialogTransitionDuration);
+        if (mobileMenuToggle) {
+          mobileMenuToggle.dataset.action = 'open';
+          mobileMenuToggle.ariaLabel = mobileMenuToggle.dataset.ariaOpen!;
+          mobileMenuToggle.focus();
+        }
+      }
+    }
+  }
+
+  const mobileMenuAnchorLinks = mobileMenu?.querySelectorAll('a[href^="#"]') || [];
+mobileMenuAnchorLinks.forEach((link) => {
+  link.addEventListener('click', handleAnchorLinkClick);
+});
+
   function handleClickOutside(target) {
     // desktop sub menu
     const desktopSubMenus = desktopMenu?.querySelectorAll('.sub-menu');


### PR DESCRIPTION
This pull request includes changes to the frontpage hero section's styling and improvements to the mobile navigation functionality. The most important changes are the addition of a new height calculation for the hero image and the enhancement of mobile menu interactions.

Styling improvements:

* [`acf-blocks/frontpage-hero/frontpage-hero.scss`](diffhunk://#diff-7ad2a9e73ff3eed76271ae04ed2f14f6a866208c708d6c615c208a7e8a92c1ffR137): Updated the hero image height to be calculated dynamically based on the viewport height minus a fixed offset.

Mobile navigation enhancements:

* [`app/js/modules/navigation.ts`](diffhunk://#diff-581e8f7e1c6be1f2609320f060f4f882060e4cd5960c2238f8bdeb44e766a468R369-R391): Added event listeners to handle sub-menu toggles and anchor link clicks within the mobile menu, ensuring the menu closes properly when an anchor link is clicked.